### PR TITLE
Return disk size when df splits line

### DIFF
--- a/lib/drive.js
+++ b/lib/drive.js
@@ -5,6 +5,8 @@ var resultUsed = 'N/A';
 var resultFree = 'N/A';
 var alert  = false;
 
+var diskPattern = /^(\S+)\n?\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(.+?)\n/mg;
+
 (function firstLaunch() {
 
     require('child_process').exec('df -k', {timeout:8000},
@@ -17,11 +19,8 @@ var alert  = false;
       var used = 0;
       var free = 0;
 
-      var lines = stdout.split("\n");
-
-      var str_disk_info = lines[1].replace( /[\s\n\r]+/g,' ');
-
-      var disk_info = str_disk_info.split(' ');
+      var lines = parseDfStdout(stdout);
+      var disk_info = lines[0];
 
       total = Math.ceil((disk_info[1] * 1024)/ Math.pow(1024,2));
       used = Math.ceil(disk_info[2] * 1024 / Math.pow(1024,2));
@@ -33,7 +32,6 @@ var alert  = false;
 
       var used_pour = (100 * used_gb/total_gb).toFixed(1);
       var free_pour = (100 * free_gb/total_gb).toFixed(1);
-
 
       if (free_pour < 10 && alert == false) {
         pmx.notify(new Error(disk_info[0] + ' Disk almost full'));
@@ -69,3 +67,14 @@ var usedDrive = probe.metric({
     return resultUsed;
   }
 });
+
+function parseDfStdout(stdout) {
+  var dfInfo = [];
+  stdout.replace(diskPattern, function() {
+    if (arguments[7] === 0) return;
+    dfInfo.push(Array.prototype.slice.call(arguments, 1, 7));
+  });
+
+  return dfInfo;
+}
+

--- a/lib/drive.js
+++ b/lib/drive.js
@@ -33,11 +33,11 @@ var diskPattern = /^(\S+)\n?\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(.+?)\n/mg;
       var used_pour = (100 * used_gb/total_gb).toFixed(1);
       var free_pour = (100 * free_gb/total_gb).toFixed(1);
 
-      if (free_pour < 10 && alert == false) {
-        pmx.notify(new Error(disk_info[0] + ' Disk almost full'));
+      if (free_pour < 10 && alert === false) {
+        pmx.notify(new Error(disk_info.Filesystem + ' Disk almost full'));
         alert = true;
       }
-      else if (free_pour > 10 && alert == true) {
+      else if (free_pour > 10 && alert === true) {
         alert = false;
       }
 

--- a/lib/drive.js
+++ b/lib/drive.js
@@ -22,9 +22,9 @@ var diskPattern = /^(\S+)\n?\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(.+?)\n/mg;
       var lines = parseDfStdout(stdout);
       var disk_info = lines[0];
 
-      total = Math.ceil((disk_info[1] * 1024)/ Math.pow(1024,2));
-      used = Math.ceil(disk_info[2] * 1024 / Math.pow(1024,2));
-      free = Math.ceil(disk_info[3] * 1024 / Math.pow(1024,2));
+      total = Math.ceil((disk_info['1K-blocks'] * 1024)/ Math.pow(1024,2));
+      used = Math.ceil(disk_info.Used * 1024 / Math.pow(1024,2));
+      free = Math.ceil(disk_info.Available * 1024 / Math.pow(1024,2));
 
       var total_gb = (total/1024).toFixed(1);
       var used_gb = (used/1024).toFixed(1);
@@ -70,11 +70,23 @@ var usedDrive = probe.metric({
 
 function parseDfStdout(stdout) {
   var dfInfo = [];
+  var headline;
   stdout.replace(diskPattern, function() {
-    if (arguments[7] === 0) return;
-    dfInfo.push(Array.prototype.slice.call(arguments, 1, 7));
+    var args = Array.prototype.slice.call(arguments, 1, 7);
+    if (arguments[7] === 0) {
+      headline = args;
+      return;
+    }
+    dfInfo.push(createDiskInfo(headline, args));
   });
 
   return dfInfo;
 }
 
+function createDiskInfo(headlineArgs, args) {
+  var info = {};
+  headlineArgs.forEach(function(h, i) {
+    info[h] = args[i];
+  });
+  return info;
+}

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
       "script": "app.js",
       "max_memory_restart": "150M"
     }
-  ]
+  ],
+  "devDependencies": {
+    "mocha": "^2.3.4"
+  }
 }

--- a/test/drive-test.js
+++ b/test/drive-test.js
@@ -1,0 +1,78 @@
+var assert = require('assert');
+var pmx = require('pmx');
+var bupProbe = pmx.probe;
+
+var childProcess = require('child_process');
+var bupExec = childProcess.exec;
+
+describe('drive', function() {
+  after(function() {
+    childProcess.exec = bupExec;
+    pmx.probe = bupProbe;
+  });
+  afterEach(function() {
+    delete require.cache[require.resolve('../lib/drive')];
+  });
+
+  it('returns disk availability and size', function(done) {
+    childProcess.exec = function(cmd, opt, callback) {
+      //jshint multistr:true
+      var stdout = "\
+Filesystem           1K-blocks     Used Available Use% Mounted on\n\
+/dev                  36580952 24822940   9893104  72% /\n\
+tmpfs                  6096496        0   6096496   0% /dev/shm\n\
+/dev/boot               487652   151545    310507  33% /boot\n\
+";
+      callback(null, stdout);
+    };
+
+    var opts = [];
+    pmx.probe = function() {
+      return {
+        metric: function(opt) {
+          opts.push(opt);
+          if (opts.length === 1) {
+            assert.equal(opt.value(), "26.9%", "Available");
+          } else if (opts.length === 2) {
+            assert.equal(opt.value(), "23.7GB / 34.9GB", "Size");
+            return done();
+          }
+        }
+      };
+    };
+
+    require('../lib/drive');
+  });
+
+  it('returns disk size when Filesystem splits line', function(done) {
+    childProcess.exec = function(cmd, opt, callback) {
+      //jshint multistr:true
+      var stdout = "\
+Filesystem           1K-blocks     Used Available Use% Mounted on\n\
+/share/dev/ssd-superdrive\n\
+                      36580952 24822940   9893104  72% /\n\
+tmpfs                  6096496        0   6096496   0% /dev/shm\n\
+/dev/boot               487652   151545    310507  33% /boot\n\
+";
+      callback(null, stdout);
+    };
+
+    var opts = [];
+    pmx.probe = function() {
+      return {
+        metric: function(opt) {
+          opts.push(opt);
+          if (opts.length === 1) {
+            assert.equal(opt.value(), "26.9%", "Available");
+          } else if (opts.length === 2) {
+            assert.equal(opt.value(), "23.7GB / 34.9GB", "Size");
+            return done();
+          }
+        }
+      };
+    };
+
+    require('../lib/drive');
+  });
+
+});


### PR DESCRIPTION
We have disks that are mounted with really long paths. This fixes the issue when the drive path info is served on two lines.

Added some tests as well.