### PR TITLE
Fix issue #19

### DIFF
--- a/lib/drive.js
+++ b/lib/drive.js
@@ -15,6 +15,11 @@ var diskPattern = /^(\S+)\n?\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(.+?)\n/mg;
       if (error) {
         return console.error('Fail: could not retrieve hard drive metrics', error);
       }
+      
+      if (!stdout) {
+        return console.error('Fail: could not retrieve hard drive metrics', 'df -k failed or timed out');
+      }
+      
       var total = 0;
       var used = 0;
       var free = 0;


### PR DESCRIPTION
Fixes issue where `df -k` times out and generates error stack:
```js
TypeError: Cannot read property 'replace' of undefined
    at /root/.pm2/node_modules/pm2-server-monit/lib/drive.js:22:35
    at ChildProcess.exithandler (child_process.js:194:7)
    at emitTwo (events.js:87:13)
    at ChildProcess.emit (events.js:172:7)
    at maybeClose (internal/child_process.js:818:16)
    at Socket. (internal/child_process.js:319:11)
    at emitOne (events.js:77:13)
    at Socket.emit (events.js:169:7)
    at Pipe._onclose (net.js:469:12)
```
This usually happens when the server is under heavy load.